### PR TITLE
Spawn local collector by default without args

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -130,21 +130,21 @@ echo "Building image with tag ${IMAGE_TAG}";
 # Get the first command line argument
 # Check if the first command line argument exists, and if not, assign it a default value
 if [ -z "$1" ]; then
-    ARG1="no_collector"
-else
     ARG1="yes_collector"
+else
+    ARG1="no_collector"
 fi
 
-if [ "$ARG1" = "no_collector" ]; then
-    COLLECTOR_PROFILE_STRING=""
-else
+if [ "$ARG1" = "yes_collector" ]; then
     COLLECTOR_PROFILE_STRING="--profile local-collector"
+else
+    COLLECTOR_PROFILE_STRING=""
 fi
 
 if ! [ -x "$(command -v docker-compose)" ]; then
     echo 'docker compose not found, trying to see if compose exists within docker';
     # assign docker compose file according to $ARG1
-    
+
     docker compose -f docker-compose.yaml pull
     if [ -n "$IPFS_URL" ]; then
         docker compose -f docker-compose.yaml --profile ipfs $COLLECTOR_PROFILE_STRING up -V --abort-on-container-exit


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #40

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [ ] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
See the linked issue for details on current behavior.

### New expected behaviour
Running `./build.sh` with no arguments will now spawn the local collector by default. Passing an argument to the `./build.sh` command will now prevent the local collector from being created.

### Change logs

#### Changed
- `./build.sh` - switched the behavior around passed args and local collector creation to prevent spawning when an arg is passed.

## Deployment Instructions
Deployment for single nodes is reverted to previous behavior with this update.
