### PR TITLE
Hotfix: saner wait time for local collector bootstrap and retry mechanisms

### DIFF
--- a/snapshotter/system_event_detector.py
+++ b/snapshotter/system_event_detector.py
@@ -103,8 +103,8 @@ class EventDetectorProcess(multiprocessing.Process):
         self._initialized = False
 
     async def init(self):
-        self._logger.info('Initializing SystemEventDetector. Awaiting local collector initialization and bootstrapping...')
-        await asyncio.sleep(20)
+        self._logger.info('Initializing SystemEventDetector. Awaiting local collector initialization and bootstrapping for 60 seconds...')
+        await asyncio.sleep(60)
         await self.processor_distributor.init()
         await self._init_check_and_report()
         await asyncio.sleep(120)

--- a/snapshotter/utils/generic_worker.py
+++ b/snapshotter/utils/generic_worker.py
@@ -216,6 +216,11 @@ class GenericAsyncWorker:
         snapshot_cid = await _ipfs_writer_client.add_bytes(snapshot)
         return snapshot_cid
 
+    @tenacity.retry(
+        wait=tenacity.wait_random_exponential(multiplier=1, max=60),
+        stop=tenacity.stop_after_attempt(3),
+        retry=tenacity.retry_if_exception_type(Exception),
+    )
     async def _submit_to_snap_api_and_check(self, project_id: str, epoch: SnapshotProcessMessage, snapshot: BaseModel):
         """
         Submits the given snapshot to the SNAP API and checks if the submission was successful.


### PR DESCRIPTION
This is a hotfix.

It increases the initialization wait time for the `SystemEventDetector` in the `snapshotter/system_event_detector.py` file from 20 seconds to 60 seconds. This change allows for sufficient time for the local collector to initialize and bootstrap before proceeding with the initialization process.

<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
<!-- Describe the code you are going to change and its behaviour -->
Read above description.

### New expected behaviour
<!-- Describe the new code and its expected behaviour -->
Read above description.

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


#### Changed
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->
* It increases the initialization wait time for the `SystemEventDetector` in the `snapshotter/system_event_detector.py` file from 20 seconds to 60 seconds. This change allows for sufficient time for the local collector to initialize and bootstrap before proceeding with the initialization process.

<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
* Stop and re-run `./build.sh`