### PR TITLE
Hotfix: Update host for local collector

### DIFF
--- a/snapshotter/utils/generic_worker.py
+++ b/snapshotter/utils/generic_worker.py
@@ -547,7 +547,7 @@ class GenericAsyncWorker:
 
     async def _init_grpc(self):
         self._grpc_channel = Channel(
-            host='snapshotter-lite-local-collector',
+            host='host.docker.internal',
             port=settings.local_collector_port,
             ssl=False,
         )


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

This is a hotfix to ensure that the local collector, when not launched as part of the same docker compose stack as the lite node, is still accessible via the `host.docker.internal` host name.

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
<!-- Describe the code you are going to change and its behaviour -->
Currently, if the local collector is launched as part of a different docker compose stack, it is not accessible by the expected hostname `snapshotter-lite-local-collector`.

### New expected behaviour
<!-- Describe the new code and its expected behaviour -->
As described in issue.

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


#### Changed
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->
* Send snapshots to local collector at the hostname `host.docker.internal`

https://github.com/PowerLoom/snapshotter-lite-v2/commit/5f136548310dcdb1c92b3d90a1327c3690c6c6c4
<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
* Re-run `./build.sh`