### PR TITLE
hotfix: add extra hosts to snapshotter-lite-v2 in compose file

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -61,6 +61,8 @@ services:
       start_period: 30s
     command:
       bash -c "bash snapshotter_autofill.sh && bash init_docker.sh"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   ipfs:
     image: ipfs/kubo:release
     profiles: ["ipfs"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,6 +60,8 @@ services:
       start_period: 30s
     command:
       bash -c "bash snapshotter_autofill.sh && bash init_docker.sh"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   ipfs:
     image: ipfs/kubo:release
     profiles: ["ipfs"]


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #44

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [ ] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
Snapshotter nodes running on some Linux distributions are unable to resolve the `host.docker.internal` hostname for the local collector component.

### New expected behaviour
Snapshotter nodes should be able to connect to the local collector on Linux distros.

### Change logs

#### Added
```bash
extra_hosts:
     - "host.docker.internal:host-gateway"
```
To `docker-compose.yaml` and `docker-compose-dev.yaml`


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
No changes.
