### PR TITLE
Delete old blanket ufw allow rule for local collector port

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ If you want to run the Snapshotter Lite Node without Docker, you need to make su
 ### Monitoring
 
 To enable Telegram reporting for snapshotter issues:
-1. Open the conversation with [@PowerloomReportingBot](https://t.me/PowerloomReportingBot) in the Telegram App and start a conversation.
+1. Open a new conversation with [@PowerloomReportingBot](https://t.me/PowerloomReportingBot) in the Telegram App.
 2. Start the bot by typing the `/start` command in the chat. You will receive a response containing your `Chat ID` for the bot.
 3. Enter the `Chat ID` when prompted on node startup.
 4. You will now receive an error report whenever your node fails to process an epoch or snapshot.

--- a/build.sh
+++ b/build.sh
@@ -132,6 +132,8 @@ fi
 
 # check if ufw command exists
 if [ -x "$(command -v ufw)" ]; then
+    # delete old blanket allow rule
+    ufw delete allow $LOCAL_COLLECTOR_PORT >> /dev/null
     ufw allow from $DOCKER_NETWORK_SUBNET to any port $LOCAL_COLLECTOR_PORT
     if [ $? -eq 0 ]; then
         echo "ufw allow rule added for local collector port ${LOCAL_COLLECTOR_PORT} to allow connections from ${DOCKER_NETWORK_SUBNET}.\n"
@@ -143,6 +145,9 @@ Then run ./build.sh again."
         # exit script if ufw rule not added
         exit 1
     fi
+else
+    echo "ufw command not found, skipping firewall rule addition for local collector port ${LOCAL_COLLECTOR_PORT}. \
+If you are on a Linux VPS, please ensure that the port is open for connections from ${DOCKER_NETWORK_SUBNET} manually to ${LOCAL_COLLECTOR_PORT}."
 fi
 
 #fetch current git branch name


### PR DESCRIPTION

<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

This is a hotfix for nodes running on Linux VPS where they had applied a blanket ufw allow rule on the local collector port to work around the issue of it not being reachable from the lite node docker container.

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
<!-- Describe the code you are going to change and its behaviour -->
As described in the PR introduction.

### New expected behaviour
<!-- Describe the new code and its expected behaviour -->
As described in the PR introduction.

### Change logs

#### Added
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->
* Delete the old `ufw allow` rule
* Helpful info message if `ufw` command was not found.


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
Pull the latest code and restart node.
