### PR TITLE
Docker build & run streamlining

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN cp config/projects.example.json config/projects.json
 RUN cp config/settings.example.json config/settings.json
 
 # Make the shell scripts executable
-RUN chmod +x ./snapshotter_autofill.sh ./init_docker.sh
+RUN chmod +x ./snapshotter_autofill.sh ./docker-entrypoint.sh
 
 # Start the application using PM2
 # CMD pm2 start pm2.config.js && pm2 logs --lines 100
+
+ENTRYPOINT ["/bin/bash", "-c", "./docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN poetry install --no-dev --no-root
 # Copy the rest of the application's files
 COPY . .
 
+RUN cp config/projects.example.json config/projects.json
+RUN cp config/settings.example.json config/settings.json
+
 # Make the shell scripts executable
 RUN chmod +x ./snapshotter_autofill.sh ./init_docker.sh
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,8 +25,6 @@ services:
       - LOCAL_COLLECTOR_PORT=$LOCAL_COLLECTOR_PORT
       - RELAYER_PRIVATE_KEY=$RELAYER_PRIVATE_KEY
       - BLOCK_TIME=$BLOCK_TIME
-    command:
-      bash -c  "bash server_autofill.sh && bash init_processes.sh"
     networks:
       - custom_network
 
@@ -62,8 +60,6 @@ services:
       timeout: 5s
       retries: 3
       start_period: 30s
-    command:
-      bash -c "bash snapshotter_autofill.sh && bash init_docker.sh"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     networks:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,3 +1,6 @@
+# Initializing settings...
+./snapshotter_autofill.sh
+
 # setting up git submodules
 git submodule update --init --recursive
 

--- a/snapshotter_autofill.sh
+++ b/snapshotter_autofill.sh
@@ -134,4 +134,4 @@ sed -i'.backup' "s#local-collector-port#$local_collector_port#" config/settings.
 sed -i'.backup' "s#https://telegram-reporting-url#$telegram_reporting_url#" config/settings.json
 sed -i'.backup' "s#telegram-chat-id#$telegram_chat_id#" config/settings.json
 
-echo 'settings has been populated!'
+echo 'settings have been populated!'

--- a/snapshotter_autofill.sh
+++ b/snapshotter_autofill.sh
@@ -72,9 +72,6 @@ if [ "$NAMESPACE" ]; then
     echo "Found NAMESPACE ${NAMESPACE}";
 fi
 
-cp config/projects.example.json config/projects.json
-cp config/settings.example.json config/settings.json
-
 
 export namespace="${NAMESPACE:-namespace_hash}"
 export ipfs_url="${IPFS_URL:-}"


### PR DESCRIPTION
### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [ ] Everything works and tested for Python 3.8.0 and above.
- [ ] I ran pre-commit checks against my changes.
- [ ] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
The overall build and run pipelines are a mess, both for this and [the collector](https://github.com/PowerLoom/snapshotter-lite-local-collector). `settings.json` and `projects.json` files being created and populated at run time is a hacky way to merge configuration sources. Similarily, the docker image does not have a default entrypoint, but does expect a very specific command in order to run at all, which is instead defined in the `docker-compose.yaml` manifest under the `command` service fields.

### New expected behaviour
This is a small PR that aims to make the docker images a little easier to work with outside of the provided `docker-compose`.

### Change logs
- The creation of `config/settings.json` and `config/projects.json` is now in the Dockerfile instead of the `snapshotter_autofill.sh` script, which shouldn't break the overall command chain but would make it possible for someone to mount a custom `settings.json` file at runtime and is overall better practice since that settings file is simply a default that is common to all container images
- Renaming `init_docker.sh` to `docker-entrypoint.sh`, which is a standard name easier to work with from the outside
- Wrapping the execution of `snapshotter_autofill.sh` inside of the newly renamed `docker-entrypoint.sh`, again making it easier to work with the container outside of the provided `docker-compose`
- Adding an `ENTRYPOINT` to the `Dockerfile` to ensure correct default behavior
- ... and as a result, removing the now redundant `command` fields from the `docker-compose` 