### PR TITLE
Fix: Telegram and issue reporting improvements 

### DIFF
--- a/snapshotter/system_event_detector.py
+++ b/snapshotter/system_event_detector.py
@@ -121,7 +121,6 @@ class EventDetectorProcess(multiprocessing.Process):
         await asyncio.sleep(60)
         await self.processor_distributor.init()
         await self._init_check_and_report()
-        await asyncio.sleep(120)
 
     async def _init_check_and_report(self):
         try:

--- a/snapshotter/utils/callback_helpers.py
+++ b/snapshotter/utils/callback_helpers.py
@@ -14,9 +14,6 @@ from snapshotter.settings.config import settings
 from snapshotter.utils.default_logger import logger
 from snapshotter.utils.models.data_models import TelegramEpochProcessingReportMessage
 from snapshotter.utils.models.data_models import TelegramSnapshotterReportMessage
-from snapshotter.utils.models.data_models import SnapshotterReportData
-from snapshotter.utils.models.data_models import EpochProcessingIssue
-from snapshotter.utils.models.message_models import EpochBase
 from snapshotter.utils.models.message_models import SnapshotProcessMessage
 from snapshotter.utils.rpc import RpcHelper
 
@@ -70,7 +67,7 @@ def sync_notification_callback_result_handler(f: functools.partial):
         logger.debug('Callback or notification result:{}', result)
 
 
-async def send_failure_notifications_async(client: AsyncClient, message: SnapshotterReportData):
+async def send_failure_notifications_async(client: AsyncClient, message: BaseModel):
     """
     Sends failure notifications to the configured reporting services.
 
@@ -81,7 +78,7 @@ async def send_failure_notifications_async(client: AsyncClient, message: Snapsho
     Returns:
         None
     """
-    
+
     if settings.reporting.service_url:
         f = asyncio.ensure_future(
             client.post(
@@ -100,24 +97,8 @@ async def send_failure_notifications_async(client: AsyncClient, message: Snapsho
         )
         f.add_done_callback(misc_notification_callback_result_handler)
 
-    if settings.reporting.telegram_url and settings.reporting.telegram_chat_id:
-        reporting_message = TelegramSnapshotterReportMessage(
-            chatId=settings.reporting.telegram_chat_id,
-            slotId=settings.slot_id,
-            issue=message.snapshotterIssue,
-            status=message.snapshotterStatus,
-        )
-        
-        f = asyncio.ensure_future(
-            client.post(
-                url=urljoin(settings.reporting.telegram_url, '/reportSnapshotIssue'),
-                json=reporting_message.dict(),
-            ),
-        )
-        f.add_done_callback(misc_notification_callback_result_handler)
 
-
-def send_failure_notifications_sync(client: SyncClient, message: SnapshotterReportData):
+def send_failure_notifications_sync(client: SyncClient, message: BaseModel):
     """
     Sends failure notifications synchronously to to the configured reporting services.
 
@@ -144,73 +125,85 @@ def send_failure_notifications_sync(client: SyncClient, message: SnapshotterRepo
         )
         sync_notification_callback_result_handler(f)
 
-    if settings.reporting.telegram_url and settings.reporting.telegram_chat_id:
-        reporting_message = TelegramSnapshotterReportMessage(
-            chatId=settings.reporting.telegram_chat_id,
-            slotId=settings.slot_id,
-            issue=message.snapshotterIssue,
-            status=message.snapshotterStatus,
+
+async def send_telegram_notification_async(client: AsyncClient, message: BaseModel):
+    """
+    Sends an asynchronous Telegram notification for reporting issues.
+
+    This function checks if Telegram reporting is configured, and then sends the appropriate
+    message based on its type (epoch processing issue or snapshotter issue).
+
+    Args:
+        client (AsyncClient): The async HTTP client to use for sending notifications.
+        message (BaseModel): The message to send as a Telegram notification. Should be either
+                             TelegramEpochProcessingReportMessage or TelegramSnapshotterReportMessage.
+
+    Returns:
+        None
+    """
+
+    if not settings.reporting.telegram_url or not settings.reporting.telegram_chat_id:
+        return
+
+    if isinstance(message, TelegramEpochProcessingReportMessage):
+        f = asyncio.ensure_future(
+            client.post(
+                url=urljoin(settings.reporting.telegram_url, '/reportEpochProcessingIssue'),
+                json=message.dict(),
+            ),
+        )
+        f.add_done_callback(misc_notification_callback_result_handler)
+    elif isinstance(message, TelegramSnapshotterReportMessage):
+        f = asyncio.ensure_future(
+            client.post(
+                url=urljoin(settings.reporting.telegram_url, '/reportSnapshotIssue'),
+                json=message.dict(),
+            ),
+        )
+        f.add_done_callback(misc_notification_callback_result_handler)
+    else:
+        helper_logger.error(
+            f'Unsupported telegram message type: {type(message)} - message not sent',
         )
 
+
+def send_telegram_notification_sync(client: SyncClient, message: BaseModel):
+    """
+    Sends a synchronous Telegram notification for reporting issues.
+
+    This function checks if Telegram reporting is configured, and then sends the appropriate
+    message based on its type (epoch processing issue or snapshotter issue).
+
+    Args:
+        client (SyncClient): The synchronous HTTP client to use for sending notifications.
+        message (BaseModel): The message to send as a Telegram notification. Should be either
+                             TelegramEpochProcessingReportMessage or TelegramSnapshotterReportMessage.
+
+    Returns:
+        None
+    """
+
+    if not settings.reporting.telegram_url or not settings.reporting.telegram_chat_id:
+        return
+
+    if isinstance(message, TelegramEpochProcessingReportMessage):
+        f = functools.partial(
+            client.post,
+            url=urljoin(settings.reporting.telegram_url, '/reportEpochProcessingIssue'),
+            json=message.dict(),
+        )
+        sync_notification_callback_result_handler(f)
+    elif isinstance(message, TelegramSnapshotterReportMessage):
         f = functools.partial(
             client.post,
             url=urljoin(settings.reporting.telegram_url, '/reportSnapshotIssue'),
-            json=reporting_message.dict(),
+            json=message.dict(),
         )
         sync_notification_callback_result_handler(f)
-
-
-async def send_epoch_processing_failure_notification_async(client: AsyncClient, message: EpochProcessingIssue):
-    """
-    Sends epoch processing failure notifications synchronously to the telegarm reporting service.
-
-    Args:
-        client (SyncClient): The HTTP client to use for sending notifications.
-        message (EpochProcessingIssue): The message to send as notification.
-
-    Returns:
-        None
-    """
-    if settings.reporting.telegram_url and settings.reporting.telegram_chat_id:
-        reporting_message = TelegramEpochProcessingReportMessage(
-            chatId=settings.reporting.telegram_chat_id,
-            slotId=settings.slot_id,
-            issue=message,
+    else:
+        helper_logger.error(
+            f'Unsupported telegram message type: {type(message)} - message not sent',
         )
-
-        f = asyncio.ensure_future(
-                client.post(
-                    url=urljoin(settings.reporting.telegram_url, '/reportEpochProcessingIssue'),
-                    json=reporting_message.dict(),
-                ),
-            )
-        f.add_done_callback(misc_notification_callback_result_handler)
-
-
-def send_epoch_processing_failure_notification_sync(client: SyncClient, message: EpochProcessingIssue):
-    """
-    Sends epoch processing failure notifications synchronously to the telegarm reporting service.
-
-    Args:
-        client (SyncClient): The HTTP client to use for sending notifications.
-        message (EpochProcessingIssue): The message to send as notification.
-
-    Returns:
-        None
-    """
-    if settings.reporting.telegram_url and settings.reporting.telegram_chat_id:
-        reporting_message = TelegramEpochProcessingReportMessage(
-            chatId=settings.reporting.telegram_chat_id,
-            slotId=settings.slot_id,
-            issue=message,
-        )
-
-        f = functools.partial(
-                client.post,
-                url=urljoin(settings.reporting.telegram_url, '/reportEpochProcessingIssue'),
-                json=reporting_message.dict(),
-            )
-        sync_notification_callback_result_handler(f)
 
 
 class GenericProcessor(ABC):

--- a/snapshotter/utils/callback_helpers.py
+++ b/snapshotter/utils/callback_helpers.py
@@ -12,11 +12,11 @@ from pydantic import BaseModel
 
 from snapshotter.settings.config import settings
 from snapshotter.utils.default_logger import logger
-from snapshotter.utils.models.data_models import TelegramEpochProcessingReportMessage
-from snapshotter.utils.models.data_models import TelegramSnapshotterReportMessage
 from snapshotter.utils.models.message_models import SnapshotProcessMessage
 from snapshotter.utils.models.message_models import SnapshotterIssue
+from snapshotter.utils.models.message_models import TelegramEpochProcessingReportMessage
 from snapshotter.utils.models.message_models import TelegramMessage
+from snapshotter.utils.models.message_models import TelegramSnapshotterReportMessage
 from snapshotter.utils.rpc import RpcHelper
 
 # setup logger

--- a/snapshotter/utils/models/data_models.py
+++ b/snapshotter/utils/models/data_models.py
@@ -194,22 +194,8 @@ class SnapshotterReportData(BaseModel):
     snapshotterStatus: SnapshotterStatus
 
 
-class TelegramSnapshotterReportMessage(BaseModel):
-    chatId: int
-    slotId: int
-    issue: SnapshotterIssue
-    status: SnapshotterStatus
-
-
 class EpochProcessingIssue(BaseModel):
     instanceID: str
     issueType: str
     timeOfReporting: str
     extra: Optional[str] = ''
-
-
-class TelegramEpochProcessingReportMessage(BaseModel):
-    chatId: int
-    slotId: int
-    issue: EpochProcessingIssue
-

--- a/snapshotter/utils/models/data_models.py
+++ b/snapshotter/utils/models/data_models.py
@@ -189,11 +189,6 @@ class TaskStatusRequest(BaseModel):
     wallet_address: str
 
 
-class SnapshotterReportData(BaseModel):
-    snapshotterIssue: SnapshotterIssue
-    snapshotterStatus: SnapshotterStatus
-
-
 class EpochProcessingIssue(BaseModel):
     instanceID: str
     issueType: str

--- a/snapshotter/utils/models/message_models.py
+++ b/snapshotter/utils/models/message_models.py
@@ -9,6 +9,7 @@ from snapshotter.utils.models.data_models import EpochProcessingIssue
 from snapshotter.utils.models.data_models import SnapshotterIssue
 from snapshotter.utils.models.data_models import SnapshotterStatus
 
+
 class TxLogsModel(BaseModel):
     logIndex: str
     blockNumber: str

--- a/snapshotter/utils/models/message_models.py
+++ b/snapshotter/utils/models/message_models.py
@@ -82,14 +82,15 @@ class ProcessHubCommand(BaseModel):
     init_kwargs: Optional[Dict] = dict()
 
 
-class TelegramEpochProcessingReportMessage(BaseModel):
+class TelegramMessage(BaseModel):
     chatId: int
     slotId: int
+
+
+class TelegramEpochProcessingReportMessage(TelegramMessage):
     issue: EpochProcessingIssue
 
 
-class TelegramSnapshotterReportMessage(BaseModel):
-    chatId: int
-    slotId: int
+class TelegramSnapshotterReportMessage(TelegramMessage):
     issue: SnapshotterIssue
     status: SnapshotterStatus

--- a/snapshotter/utils/models/message_models.py
+++ b/snapshotter/utils/models/message_models.py
@@ -83,7 +83,7 @@ class ProcessHubCommand(BaseModel):
 
 
 class TelegramMessage(BaseModel):
-    chatId: int
+    chatId: str
     slotId: int
 
 

--- a/snapshotter/utils/models/message_models.py
+++ b/snapshotter/utils/models/message_models.py
@@ -5,6 +5,9 @@ from typing import Optional
 from pydantic import BaseModel
 from pydantic import Field
 
+from snapshotter.utils.models.data_models import EpochProcessingIssue
+from snapshotter.utils.models.data_models import SnapshotterIssue
+from snapshotter.utils.models.data_models import SnapshotterStatus
 
 class TxLogsModel(BaseModel):
     logIndex: str
@@ -76,3 +79,16 @@ class ProcessHubCommand(BaseModel):
     pid: Optional[int] = None
     proc_str_id: Optional[str] = None
     init_kwargs: Optional[Dict] = dict()
+
+
+class TelegramEpochProcessingReportMessage(BaseModel):
+    chatId: int
+    slotId: int
+    issue: EpochProcessingIssue
+
+
+class TelegramSnapshotterReportMessage(BaseModel):
+    chatId: int
+    slotId: int
+    issue: SnapshotterIssue
+    status: SnapshotterStatus


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes ##58

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
The implementation of the telegram issue reporting service is currently inconsistent with established internal patterns, and the handling of httpx clients used is incorrect/can be improved.

### New expected behaviour
I have separated the telegram reporting logic from the reporting service's in `utils/callback_helpers.py`. Two new functions called `send_telegram_notification_sync` and `send_telegram_notification_async` have been created. These will handle sending the notification message to the correct telegram service endpoint depending on the issue that was raised. 

An additional `httpx` client has been added to the core snapshotter services that opens a connection pool against the telegram reporting service endpoint. The telegram and reporting service notifications will now each have their own callback helpers and clients.

The call to sleep in `system_event_detector` after `_init_check_and_report()` has completed has also been removed. 


### Change logs


#### Changed
- `utils/callback_helpers.py`
  - created separate helpers for telegram notifications
  - reverted changes to internal reporting helpers
- `system_event_detector.py`
  - updated issue reporting for new callback helpers
  - `_send_telegram_epoch_processing_notification()` created to remove duplicate code
  - added `self._telegram_httpx_client`
  - removed sleep after simulation submissions are complete
- `processor_distributor.py`
  - updated issue reporting for new callback helpers
  - `_send_failure_notifications()` created to handle internal/telegram reporting and remove duplicate code
  - added `self._telegram_httpx_client`
- `utils/generic_worker.py`
  - updated issue reporting for new callback helpers
  - `_send_failure_notifications()` created to handle internal/telegram reporting and remove duplicate code
  - added `self._telegram_httpx_client`
- `utils/snapshot_worker.py`
  - updated issue reporting for new callback helpers
  - uses inherited notification method
- `utils/models/`
  - updated telegram message models and moved them to the `message_models` file
  - removed deprecated models due to reporting changes


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


#### Removed
- `SnapshotterReportData` from `utils/models/data_models.py`


## Deployment Instructions
No changes to deployment.
