### PR TITLE
Hotfix/docker subnet last octet

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,9 +52,6 @@ if [ -z "$OVERRIDE_DEFAULTS" ]; then
     export DATA_MARKET_CONTRACT="0x0C2E22fe7526fAeF28E7A58c84f8723dEFcE200c"
     export PROST_CHAIN_ID="11169"
     export DOCKER_NETWORK_NAME="snapshotter-lite-v2-${SLOT_ID}"
-    # We're now using the range 172.16.0.0 to 172.31.255.255 for our subnets, which is the correct private IP range.
-    # This approach provides 1,048,576 unique subnets before wrapping around, which should be sufficient for most use cases.
-    # The calculation ensures each slot ID gets a unique subnet within this range.
     SUBNET_SECOND_OCTET=$((16 + (SLOT_ID / 65536) % 16))
     SUBNET_THIRD_OCTET=$(((SLOT_ID / 256) % 256))
     SUBNET_FOURTH_OCTET=$((SLOT_ID % 256))

--- a/build.sh
+++ b/build.sh
@@ -54,8 +54,8 @@ if [ -z "$OVERRIDE_DEFAULTS" ]; then
     export DOCKER_NETWORK_NAME="snapshotter-lite-v2-${SLOT_ID}"
     SUBNET_SECOND_OCTET=$((16 + (SLOT_ID / 65536) % 16))
     SUBNET_THIRD_OCTET=$(((SLOT_ID / 256) % 256))
-    SUBNET_FOURTH_OCTET=$((SLOT_ID % 256))
-    export DOCKER_NETWORK_SUBNET="172.${SUBNET_SECOND_OCTET}.${SUBNET_THIRD_OCTET}.${SUBNET_FOURTH_OCTET}/24"
+    # Always use 0 for the fourth octet to ensure a valid subnet
+    export DOCKER_NETWORK_SUBNET="172.${SUBNET_SECOND_OCTET}.${SUBNET_THIRD_OCTET}.0/24"
 
     echo "Selected DOCKER_NETWORK_NAME: ${DOCKER_NETWORK_NAME}"
     echo "Selected DOCKER_NETWORK_SUBNET: ${DOCKER_NETWORK_SUBNET}"
@@ -65,34 +65,32 @@ if [ -z "$OVERRIDE_DEFAULTS" ]; then
         local test_slot_id=$1
         local expected_second_octet=$2
         local expected_third_octet=$3
-        local expected_fourth_octet=$4
 
         SLOT_ID=$test_slot_id
         SUBNET_SECOND_OCTET=$((16 + (SLOT_ID / 65536) % 16))
         SUBNET_THIRD_OCTET=$(((SLOT_ID / 256) % 256))
-        SUBNET_FOURTH_OCTET=$((SLOT_ID % 256))
+        SUBNET="172.${SUBNET_SECOND_OCTET}.${SUBNET_THIRD_OCTET}.0/24"
 
         if [ $SUBNET_SECOND_OCTET -eq $expected_second_octet ] && 
-           [ $SUBNET_THIRD_OCTET -eq $expected_third_octet ] && 
-           [ $SUBNET_FOURTH_OCTET -eq $expected_fourth_octet ]; then
-            echo "Test passed for SLOT_ID $test_slot_id: 172.$SUBNET_SECOND_OCTET.$SUBNET_THIRD_OCTET.$SUBNET_FOURTH_OCTET/24"
+           [ $SUBNET_THIRD_OCTET -eq $expected_third_octet ]; then
+            echo "Test passed for SLOT_ID $test_slot_id: $SUBNET"
         else    
-            echo "Test failed for SLOT_ID $test_slot_id: Expected 172.$expected_second_octet.$expected_third_octet.$expected_fourth_octet/24, got 172.$SUBNET_SECOND_OCTET.$SUBNET_THIRD_OCTET.$SUBNET_FOURTH_OCTET/24"
+            echo "Test failed for SLOT_ID $test_slot_id: Expected 172.$expected_second_octet.$expected_third_octet.0/24, got $SUBNET"
         fi
     }
 
     # Run tests
     echo "Running subnet calculation tests..."
-    test_subnet_calculation 1 16 0 1
-    test_subnet_calculation 255 16 0 255
-    test_subnet_calculation 256 16 1 0
-    test_subnet_calculation 1000 16 3 232
-    test_subnet_calculation 10000 16 39 16
-    test_subnet_calculation 65535 16 255 255
-    test_subnet_calculation 65536 17 0 0
-    test_subnet_calculation 100000 17 134 160
-    test_subnet_calculation 1048575 31 255 255
-    test_subnet_calculation 1048576 16 0 0
+    test_subnet_calculation 1 16 0
+    test_subnet_calculation 255 16 0
+    test_subnet_calculation 256 16 1
+    test_subnet_calculation 1000 16 3
+    test_subnet_calculation 10000 16 39
+    test_subnet_calculation 65535 16 255
+    test_subnet_calculation 65536 17 0
+    test_subnet_calculation 100000 17 134
+    test_subnet_calculation 1048575 31 255
+    test_subnet_calculation 1048576 16 0
     # Add this line to run tests before the main script logic
     [ "$1" = "--test" ] && exit 0
 fi


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

This is a hotfix to ensure the /24 subnet mask applied to Class B private IP addresses and assigned as the Docker subnet always has the last octet in the representation as `0`.

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
<!-- Describe the code you are going to change and its behaviour -->
Currently, it has a faulty logic of assigning values from 0 to 255 in the last octet even though the mask is `/24`. 

### New expected behaviour
<!-- Describe the new code and its expected behaviour -->
As described above.

### Change logs

As described above. 
<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
* Stop the node
* pull the latest code
* re-run `./build.sh`