### PR TITLE
Feat: restarting local collector on failure

### DIFF
--- a/build-dev.sh
+++ b/build-dev.sh
@@ -234,14 +234,14 @@ echo "building...";
 if ! [ -x "$(command -v docker-compose)" ]; then
     echo 'docker compose not found, trying to see if compose exists within docker';
     if [ "$IPFS_URL" == "/dns/ipfs/tcp/5001" ]; then
-        docker compose -f docker-compose-dev.yaml --profile ipfs up -V --abort-on-container-exit
+        docker compose -f docker-compose-dev.yaml --profile ipfs up -V
     else
-        docker compose -f docker-compose-dev.yaml up --no-deps -V --abort-on-container-exit
+        docker compose -f docker-compose-dev.yaml up --no-deps -V
     fi
 else
     if [ "$IPFS_URL" == "/dns/ipfs/tcp/5001" ]; then
-        docker-compose -f docker-compose-dev.yaml --profile ipfs up -V --abort-on-container-exit
+        docker-compose -f docker-compose-dev.yaml --profile ipfs up -V
     else
-        docker-compose -f docker-compose-dev.yaml up --no-deps -V --abort-on-container-exit
+        docker-compose -f docker-compose-dev.yaml up --no-deps -V
     fi
 fi

--- a/build.sh
+++ b/build.sh
@@ -270,16 +270,16 @@ if ! [ -x "$(command -v docker-compose)" ]; then
 
     docker compose -f docker-compose.yaml $COLLECTOR_PROFILE_STRING pull
     if [ -n "$IPFS_URL" ]; then
-        docker compose -f docker-compose.yaml --profile ipfs $COLLECTOR_PROFILE_STRING up -V --abort-on-container-exit
+        docker compose -f docker-compose.yaml --profile ipfs $COLLECTOR_PROFILE_STRING up -V
     else
-        docker compose -f docker-compose.yaml $COLLECTOR_PROFILE_STRING up -V --abort-on-container-exit
+        docker compose -f docker-compose.yaml $COLLECTOR_PROFILE_STRING up -V
     fi
 else
     docker-compose -f docker-compose.yaml $COLLECTOR_PROFILE_STRING pull
     if [ -n "$IPFS_URL" ]; then
-        docker-compose -f docker-compose.yaml --profile ipfs $COLLECTOR_PROFILE_STRING up -V --abort-on-container-exit
+        docker-compose -f docker-compose.yaml --profile ipfs $COLLECTOR_PROFILE_STRING up -V
     else
-        docker-compose -f docker-compose.yaml $COLLECTOR_PROFILE_STRING up -V --abort-on-container-exit
+        docker-compose -f docker-compose.yaml $COLLECTOR_PROFILE_STRING up -V
     fi
 fi
 

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -31,7 +31,7 @@ services:
       - MAX_CONCURRENT_WRITES=$MAX_CONCURRENT_WRITES
     networks:
       - custom_network
-
+    restart: on-failure:10
   snapshotter-lite-v2:
     image: snapshotter-lite-v2
     expose:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
       - MAX_CONCURRENT_WRITES=$MAX_CONCURRENT_WRITES
     networks:
       - custom_network
-
+    restart: on-failure:10
   snapshotter-lite-v2:
     image: ghcr.io/powerloom/snapshotter-lite-v2:${IMAGE_TAG}
     expose:


### PR DESCRIPTION
### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and is tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.

### Current behaviour
If the snapshotter lite local collector exits for some reason, the entire node stops
### New expected behaviour
 docker should automatically restart the snapshotter local collector if it exits for some reason
