### PR TITLE
FIX: Do not simulate submissions and reporting service ping on identity check failure

### DIFF
--- a/build-dev.sh
+++ b/build-dev.sh
@@ -213,9 +213,6 @@ else
 If you are on a Linux VPS, please ensure that the port is open for connections from ${DOCKER_NETWORK_SUBNET} manually to ${LOCAL_COLLECTOR_PORT}."
 fi
 
-# setting up git submodules
-git submodule update --init --recursive
-
 # Remove existing directory if it exists
 if [ -d "./snapshotter-lite-local-collector" ]; then
     echo "Removing existing snapshotter-lite-local-collector directory..."

--- a/init.sh
+++ b/init.sh
@@ -42,9 +42,6 @@ echo "Killing old processes..."
 pkill -f snapshotter
 # only works for debian based systems
 
-# setting up git submodules
-git submodule update --init --recursive
-
 ./snapshotter_autofill.sh || exit 1
 
 # check python3 is present

--- a/init_docker.sh
+++ b/init_docker.sh
@@ -1,5 +1,10 @@
-# setting up git submodules
-git submodule update --init --recursive
+poetry run python -m snapshotter.snapshotter_id_ping
+ret_status=$?
+
+if [ $ret_status -ne 0 ]; then
+    echo "Snapshotter identity check failed on protocol smart contract"
+    exit 1
+fi
 
 echo 'starting processes...';
 pm2 start pm2.config.js

--- a/snapshotter/processor_distributor.py
+++ b/snapshotter/processor_distributor.py
@@ -170,20 +170,6 @@ class ProcessorDistributor:
                 self._epoch_size = epoch_size
 
             try:
-                snapshotter_address = self._protocol_state_contract.functions.slotSnapshotterMapping(
-                    settings.slot_id,
-                ).call()
-                if snapshotter_address != to_checksum_address(settings.instance_id):
-                    self._logger.error('Signer Account is not the one configured in slot, exiting!')
-                    exit(0)
-            except Exception as e:
-                self._logger.error(
-                    'Exception in querying protocol state for snapshotter status: {}',
-                    e,
-                )
-                exit(0)
-
-            try:
                 self._current_day = self._protocol_state_contract.functions.dayCounter(Web3.to_checksum_address(settings.data_market)).call()
 
                 task_completion_status = self._protocol_state_contract.functions.checkSlotTaskStatusForDay(

--- a/snapshotter/snapshotter_id_ping.py
+++ b/snapshotter/snapshotter_id_ping.py
@@ -1,0 +1,52 @@
+import asyncio
+import sys
+
+from web3 import Web3
+
+from snapshotter.settings.config import settings
+from snapshotter.utils.file_utils import read_json_file
+
+
+async def main():
+    """
+    Checks if snapshotting is allowed for the given instance ID by querying the protocol state contract.
+    If snapshotting is allowed, sets the active status key in Redis to True and exits with code 0.
+    If snapshotting is not allowed, sets the active status key in Redis to False and exits with code 1.
+    """
+    # Load protocol state ABI
+    protocol_abi = read_json_file(settings.protocol_state.abi)
+    print('abi file ', settings.protocol_state.abi)
+    print('Contract address: ', settings.protocol_state.address)
+
+    w3 = Web3(Web3.HTTPProvider(settings.anchor_chain_rpc.full_nodes[0].url))
+
+    protocol_state_contract = w3.eth.contract(address=settings.protocol_state.address, abi=protocol_abi)
+    # Query allowed snapshotters
+    allowed_snapshotters = protocol_state_contract.functions.allSnapshotters(
+        Web3.to_checksum_address(settings.instance_id)
+    ).call()
+
+    if allowed_snapshotters is True or allowed_snapshotters:
+        print('Snapshotter identity found in allowed snapshotters...')
+    else:
+        print('Snapshotter identity not found in allowed snapshotters...')
+        sys.exit(1)
+
+    # Check slot ID mapping
+    slot_id_mapping_query = protocol_state_contract.functions.slotSnapshotterMapping(
+        settings.slot_id
+    ).call()
+
+    try:
+        slot_id_snapshotter_addr = Web3.to_checksum_address(slot_id_mapping_query[0])
+        if slot_id_snapshotter_addr == Web3.to_checksum_address(settings.instance_id):
+            print('Snapshotter identity found in slot ID mapping...')
+        else:
+            print('Snapshotter identity not found in slot ID mapping...')
+            sys.exit(1)
+    except Exception as e:
+        print('Error in slot ID mapping query: ', e)
+        sys.exit(1)
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
Fixes #37 

### Checklist
- [x] My branch is up-to-date with the upstream/develop branches.
- [x] Everything works and is tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes, and all the current tests are passing.

### Current behaviour
The node sends simulation submissions and a ping to the reporting service even if its identity check fails.

### New expected behaviour
If the identity check fails, the node should exit without sending pings or simulation submissions.