### PR TITLE
Hotix: Restore automatic subnet selection behavior

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -269,7 +269,7 @@ if [ "$SUBNET_IN_USE" = "yes" ] || [ -z "$NETWORK_EXISTS" ]; then
         if [ "$FOUND_AVAILABLE_SUBNET" = "true" ]; then
             echo "🟢 Found available subnet: 172.18.${AVAILABLE_SUBNET_OCTET}.0/24"
             # select subnet by default unless the command line argument is passed
-            if [ "$DOCKER_NETWORK_PRUNE" != "true" ]; then
+            if [ "$DOCKER_NETWORK_PRUNE" = "true" ]; then
                 echo "🫸 ▶︎ Would you like to use this subnet? (y/n): "
                 read USE_FOUND_SUBNET
             else


### PR DESCRIPTION

<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Corrects the condition for subnet selection prompts where `DOCKER_NETWORK_PRUNE` was incorrectly negated. This fix:

- Restores automatic subnet selection when `--docker-network-prune` flag is not used
- Only prompts for subnet selection choices when explicitly requested via the flag
- Maintains the power user option to control subnet selection when needed

The change ensures better UX by defaulting to automatic behavior for most users while preserving manual control options.
### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
The condition `if [ "$DOCKER_NETWORK_PRUNE" != "true" ]` incorrectly prompts for subnet selection choices by default, requiring user interaction even when not requested. This negated condition forces manual intervention for all users instead of only power users who explicitly request control via the `--docker-network-prune` flag.

### New expected behaviour
The corrected condition `if [ "$DOCKER_NETWORK_PRUNE" = "true" ]` restores the intended behavior where:
- By default, subnet selection happens automatically without user prompts
- Manual subnet selection choices only appear when explicitly requested via `--docker-network-prune`
- Power users maintain the ability to control subnet selection when needed

### Change logs

#### Changed
- Modified subnet selection logic condition from `!=` to `=` to restore correct prompt behavior
- Improved user experience by defaulting to automatic subnet selection for standard usage

#### Fixed
- Fixed inverted condition that was forcing manual subnet selection prompts on all users
- Restored intended behavior where `--docker-network-prune` flag properly controls when manual intervention is requested


## Deployment Instructions
* Pull the latest `dockerify` and test. For multi-node setup, just change the git clone to use `dockerify` branch of this lite node repo
