### PR TITLE
Update port range in collector_test.sh and enhance directory checks i…

### DIFF
--- a/collector_test.sh
+++ b/collector_test.sh
@@ -65,7 +65,7 @@ if [ "$test_ping" = true ] && [ "$test_namespace" = true ]; then
     exit 100
 else
     echo "⚠️  No active collector found - searching for available ports..."
-    for port in {50051..50059}; do
+    for port in {50051..51050}; do
         if ! nc -z localhost $port 2>/dev/null; then
             echo "✅ Found available port: $port"
             sed -i".backup" "s/^LOCAL_COLLECTOR_PORT=.*/LOCAL_COLLECTOR_PORT=${port}/" "${ENV_FILE}"

--- a/diagnose.sh
+++ b/diagnose.sh
@@ -123,12 +123,13 @@ echo -e "\n📁 Checking for PowerLoom deployment directories..."
 # Matches patterns like:
 # - powerloom-premainnet-v2-*
 # - powerloom-testnet-v2-*
+# - powerloom-mainnet-v2-*
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # macOS version
-    EXISTING_DIRS=$(find . -maxdepth 1 -type d \( -name "powerloom-premainnet-v2-*" -o -name "powerloom-testnet*" \) -exec basename {} \; || true)
+    EXISTING_DIRS=$(find . -maxdepth 1 -type d \( -name "powerloom-premainnet-v2-*" -o -name "powerloom-testnet*" -o -name "powerloom-mainnet-v2-*" \) -exec basename {} \; || true)
 else
-    # Linux version (unchanged)
-    EXISTING_DIRS=$(find . -maxdepth 1 -type d -name "powerloom-premainnet-v2-*" -o -name "powerloom-testnet*" -exec basename {} \; || true)
+    # Linux version
+    EXISTING_DIRS=$(find . -maxdepth 1 -type d \( -name "powerloom-premainnet-v2-*" -o -name "powerloom-testnet*" -o -name "powerloom-mainnet-v2-*" \) -exec basename {} \; || true)
 fi
 
 if [ -n "$EXISTING_DIRS" ]; then
@@ -178,7 +179,7 @@ fi
 
 # Check for existing screen sessions
 echo -e "\n🖥️ Checking existing PowerLoom screen sessions..."
-EXISTING_SCREENS=$(screen -ls | grep -E 'powerloom-(premainnet|testnet)-v2|snapshotter' || true)
+EXISTING_SCREENS=$(screen -ls | grep -E 'powerloom-(premainnet|testnet|mainnet)-v2|snapshotter' || true)
 if [ -n "$EXISTING_SCREENS" ]; then
     echo -e "${YELLOW}Found existing PowerLoom screen sessions:${NC}"
     echo "$EXISTING_SCREENS"


### PR DESCRIPTION
# Port Range Expansion and Diagnostic Script Enhancement

This is a hotfix to expand the port range on which local collector allocation takes place as well as some basic cleanup operations being added to the diagnose script to accommodate custom multi node installations.

Fixes #

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
- Local collector port allocation is limited to a small range (50051-50059), which may cause issues in multi-node setups
- Diagnostic script lacks support for mainnet deployment cleanup

### New expected behaviour
- Expanded port range allows for up to 1000 concurrent collectors
- Diagnostic script now properly handles mainnet deployment directories and screen sessions
- Improved cleanup capabilities for multi-node installations

### Change logs

#### Changed
- Expanded collector port range from 50051-50059 to 50051-51050 in collector_test.sh
- Updated directory pattern matching in diagnose.sh to include 'powerloom-mainnet-v2-*'
- Enhanced screen session detection to include mainnet deployments

## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
* stop node
* run `./diagnose.sh` for cleanup
* re-run `./build.sh`
