### PR TITLE
hotfix: namespaced autoheal service in Docker Compose

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -60,11 +60,11 @@ check_wsl() {
 # Configure Docker Compose profiles based on WSL environment
 if check_wsl; then
     # WSL environment - disable autoheal
-    COMPOSE_PROFILES="--profile local-collector"
+    COMPOSE_PROFILES="${COLLECTOR_PROFILE_STRING}"
     export AUTOHEAL_LABEL=""
 else
     # Non-WSL environment - enable autoheal
-    COMPOSE_PROFILES="--profile local-collector --profile autoheal"
+    COMPOSE_PROFILES="${COLLECTOR_PROFILE_STRING} --profile autoheal"
     export AUTOHEAL_LABEL="autoheal=true"
 fi
 

--- a/diagnose.sh
+++ b/diagnose.sh
@@ -82,7 +82,7 @@ fi
 
 # Check existing containers and networks
 echo -e "\n🔍 Checking existing PowerLoom containers..."
-EXISTING_CONTAINERS=$(docker ps -a --filter "name=snapshotter-lite-v2" --filter "name=powerloom" --filter "name=local-collector" --format "{{.Names}}")
+EXISTING_CONTAINERS=$(docker ps -a --filter "name=snapshotter-lite-v2" --filter "name=powerloom" --filter "name=autoheal" --filter "name=local-collector" --format "{{.Names}}")
 if [ -n "$EXISTING_CONTAINERS" ]; then
     echo -e "${YELLOW}Found existing PowerLoom containers:${NC}"
     echo "$EXISTING_CONTAINERS"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,8 @@
 services:
   autoheal:
+    container_name: autoheal-snapshotter-lite-v2-${SLOT_ID}-${FULL_NAMESPACE}
     profiles: ["autoheal"]
     image: willfarrell/autoheal
-    container_name: autoheal
     restart: always
     environment:
       - AUTOHEAL_CONTAINER_LABEL=autoheal


### PR DESCRIPTION


### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
- Autoheal container uses a static name `autoheal`
- Multiple snapshotter instances on same machine cause container name conflicts
- Prevents running multiple snapshotter instances due to container name collision

### New expected behaviour
- Autoheal container name includes namespace and slot ID
- Multiple snapshotter instances can run on the same machine
- Consistent naming convention with other containers in the stack

### Change logs

#### Changed
- Updated autoheal container name in docker-compose.yaml to include namespace and slot ID:
  ```yaml
  container_name: autoheal-snapshotter-lite-v2-${SLOT_ID}-${FULL_NAMESPACE}
  ```

#### Fixed
- Container name collision when running multiple snapshotter instances
- Consistency in container naming across the stack

## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
* Pull `dockerify` and run
