### PR TITLE
Hotfix: namespaced Docker subnet and label assignment for autoheal service

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -65,7 +65,7 @@ if check_wsl; then
 else
     # Non-WSL environment - enable autoheal
     COMPOSE_PROFILES="${COLLECTOR_PROFILE_STRING} --profile autoheal"
-    export AUTOHEAL_LABEL="autoheal=true"
+    export AUTOHEAL_LABEL="autoheal-${SLOT_ID}-${FULL_NAMESPACE}=true"
 fi
 
 # Modify the deploy-services call to use the profiles

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,10 +5,12 @@ services:
     image: willfarrell/autoheal
     restart: always
     environment:
-      - AUTOHEAL_CONTAINER_LABEL=autoheal
+      - AUTOHEAL_CONTAINER_LABEL=autoheal-${SLOT_ID}-${FULL_NAMESPACE}
     volumes:
       # Needs access to docker socket to monitor containers
       - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - custom_network
   snapshotter-lite-local-collector:
     image: ghcr.io/powerloom/snapshotter-lite-local-collector:${IMAGE_TAG}
     container_name: snapshotter-lite-local-collector-${SLOT_ID}-${FULL_NAMESPACE}


### PR DESCRIPTION
…and within the custom network

<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #106 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
<!-- Describe the code you are going to change and its behaviour -->
Refer to issue description

### New expected behaviour
<!-- Describe the new code and its expected behaviour -->
Refer to issue description

### Change logs

#### Added
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->
* autoheal container on the same Docker subnet as the snapshotter and the [optional]local collector it was spawned together with.

#### Changed
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->
* `AUTOHEAL_LABEL` considered for healing by the autoheal service is namespaced as `export AUTOHEAL_LABEL="autoheal-${SLOT_ID}-${FULL_NAMESPACE}=true"`

<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
* Refer issue description
