### PR TITLE
Randomize Docker restart of container when memory limit is breached

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -79,7 +79,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 150M
+          memory: 145M
 networks:
   custom_network:
     name: ${DOCKER_NETWORK_NAME}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -79,7 +79,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 145M
+          memory: 200M
 networks:
   custom_network:
     name: ${DOCKER_NETWORK_NAME}

--- a/init_docker.sh
+++ b/init_docker.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+handle_exit() {
+    EXIT_CODE=$?
+    # Random delay between 1-5 minutes, spread between 30 seconds
+    MIN_DELAY=30
+    MAX_DELAY=300
+    ACTUAL_DELAY=$((MIN_DELAY + RANDOM % (MAX_DELAY - MIN_DELAY + 1)))
+    
+    echo "Container exited with code $EXIT_CODE. Restarting in $ACTUAL_DELAY seconds..."
+    sleep $ACTUAL_DELAY
+    exec "$0" "$@"  # Restart the script
+}
+
 # Always run bootstrap
 echo "🚀 Running bootstrap..."
 
@@ -35,5 +47,8 @@ if [ $ret_status -ne 0 ]; then
     echo "Snapshotter identity check failed on protocol smart contract"
     exit 1
 fi
+
+# Set up traps for all possible exit scenarios
+trap 'handle_exit' EXIT HUP INT QUIT ABRT TERM KILL
 
 poetry run python -m snapshotter.system_event_detector


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #119 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
<!-- Describe the code you are going to change and its behaviour -->
Refer issue description.

### New expected behaviour
<!-- Describe the new code and its expected behaviour -->
Refer issue description.

### Change logs

#### Added
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->
* Signal handler in `init_docker.sh` that intercepts shutdown OS signals and introduces a randomized delay.

#### Changed
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->
* Increased threshold for memory limit before Docker restart kicks in for snapshotter lite v2 container to 200 MB.

<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
* Pull the `experimental` branch and re-run `./build.sh`
