### PR TITLE
fix: always exiting with 1 to force docker restart

### DIFF
--- a/init_docker.sh
+++ b/init_docker.sh
@@ -9,6 +9,7 @@ handle_exit() {
     
     echo "Container exited with code $EXIT_CODE. Restarting in $ACTUAL_DELAY seconds..."
     sleep $ACTUAL_DELAY
+    exit 1
 }
 
 # Always run bootstrap


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #131 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.


## Testing
Already tested and live on dockerify branch