### PR TITLE
feat: add --devnet flag for streamlined devnet setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,33 @@ You will be prompted to choose whether you wish to change the previously configu
 
 Choose `y` or `n` depending on whether you wish to change them.
 
+#### Quick Devnet Setup
+
+The `build.sh` script provides a `--devnet` flag for quick devnet deployment without manual configuration prompts.
+
+To use this feature, run:
+```bash
+./build.sh --devnet
+```
+
+When the `--devnet` flag is used:
+1. The script automatically configures for devnet chain
+2. Uses devnet-specific defaults:
+   - Devnet RPC URL: `https://rpc-devnet.powerloom.dev`
+   - Devnet Protocol State Contract: `0x3B5A0FB70ef68B5dd677C7d614dFB89961f97401`
+   - Devnet Data Market Contracts (Uniswap V2 by default)
+3. Auto-selects existing devnet environment files (if multiple exist, uses the first one)
+4. Skips chain selection prompts for faster setup
+5. Sets `OVERRIDE_DEFAULTS=true` to preserve devnet configuration
+
+You can combine this with other flags:
+```bash
+./build.sh --devnet --skip-credential-update
+./build.sh --devnet --data-market-contract-number 1  # For Aave V3 on devnet
+```
+
+This is ideal for developers who frequently switch between mainnet and devnet environments.
+
 #### Overriding Default .env Generation
 
 The `build.sh` script provides a mechanism to override the default generation of the `.env` file and customize various configuration parameters. This is useful when you need a specific setup that differs from the standard defaults or an existing `.env` configuration.


### PR DESCRIPTION
Enhances #133 

  - Add --devnet flag to build.sh for automatic devnet configuration
  - Merge get_data_market_config functions to reduce code duplication
  - Auto-detect and select devnet environment files when --devnet is used
  - Add devnet-specific defaults for RPC URL, contracts, and chain config
  - Update README with documentation for the new --devnet flag
  - Skip manual prompts for faster devnet deployment
