### PR TITLE
Fix: Fallback to TCP ping to test local collector port instead of `netcat` 

### DIFF
--- a/test_collector_check.sh
+++ b/test_collector_check.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Create a temporary env file
+echo "Creating test env file..."
+cat > test.env << EOL
+FULL_NAMESPACE=TEST-MAINNET-ETH
+LOCAL_COLLECTOR_PORT=50051
+EOL
+
+# Export required variables
+export FULL_NAMESPACE=TEST-MAINNET-ETH
+
+# Function to run the test
+run_test() {
+    local nc_available=$1
+    local expected_port_in_use=$2
+    local test_description=$3
+    
+    echo "🧪 Test: $test_description"
+    
+    if [ "$nc_available" = "false" ]; then
+        # Create a function that overrides the command -v behavior for nc
+        command() {
+            if [ "$2" = "nc" ]; then
+                return 1
+            fi
+            builtin command "$@"
+        }
+        export -f command
+        echo "  Disabled nc check via function override"
+    else
+        # Restore normal command behavior
+        unset -f command
+        echo "  Restored normal command behavior"
+    fi
+    
+    if [ "$expected_port_in_use" = "true" ]; then
+        echo "  Starting dummy service on port 50051..."
+        nc -l 50051 &
+        NC_PID=$!
+        sleep 1
+    fi
+    
+    echo "  Running collector_test.sh..."
+    ./collector_test.sh --env-file test.env
+    TEST_RESULT=$?
+    
+    if [ "$expected_port_in_use" = "true" ]; then
+        echo "  Stopping dummy service..."
+        kill $NC_PID 2>/dev/null
+    fi
+    
+    echo "  Test result code: $TEST_RESULT"
+    return $TEST_RESULT
+}
+
+# Function to kill any process using our test port
+cleanup_port() {
+    echo "Cleaning up port 50051..."
+    lsof -ti:50051 | xargs kill -9 2>/dev/null || true
+    sleep 1
+}
+
+# Test scenarios
+echo "Running test scenarios..."
+
+# Initial cleanup
+cleanup_port
+
+# Test 1: With nc, port free
+run_test "true" "false" "With netcat, port is free"
+cleanup_port
+
+# Test 2: With nc, port in use
+run_test "true" "true" "With netcat, port is in use"
+cleanup_port
+
+# Test 3: Without nc, port free
+run_test "false" "false" "Without netcat, port is free"
+cleanup_port
+
+# Test 4: Without nc, port in use
+run_test "false" "true" "Without netcat, port is in use"
+cleanup_port
+
+# Cleanup
+echo "Cleaning up..."
+rm -f test.env
+unset -f command  # Ensure command function is unset
+
+echo "Tests completed!"

--- a/test_collector_check.sh
+++ b/test_collector_check.sh
@@ -20,13 +20,11 @@ run_test() {
     echo "🧪 Test: $test_description"
     
     if [ "$nc_available" = "false" ]; then
-        # Create functions that override command behavior for nc, netcat and curl
+        # Create functions that override command behavior for nc and netcat
         command() {
             if [ "$2" = "nc" ]; then
                 return 1
             elif [ "$2" = "netcat" ]; then
-                return 1
-            elif [ "$curl_available" = "false" ] && [ "$2" = "curl" ]; then
                 return 1
             fi
             builtin command "$@"
@@ -35,9 +33,6 @@ run_test() {
         # Override the actual commands too
         nc() { return 1; }
         netcat() { return 1; }
-        if [ "$curl_available" = "false" ]; then
-            curl() { return 1; }
-        fi
         export -f command
         echo "  Disabled nc/netcat check via function override"
         if [ "$curl_available" = "false" ]; then
@@ -102,31 +97,31 @@ echo "Running test scenarios..."
 # Initial cleanup
 cleanup_port
 
-echo "🧪 Testing with tools available..."
+echo "🧪 Testing with nc available..."
 # Test 1: With nc, port free (should exit 101)
-run_test "true" "true" "false" "With netcat and curl, port is free"
+run_test "true" "true" "false" "With nc, port is free"
 cleanup_port
 
 # Test 2: With nc, port in use (should exit 100)
-run_test "true" "true" "true" "With netcat and curl, port is in use"
+run_test "true" "true" "true" "With nc, port is in use"
 cleanup_port
 
-echo "🧪 Testing with curl fallback..."
-# Test 3: Without nc but with curl, port free (should exit 101)
-run_test "false" "true" "false" "Without netcat but with curl, port is free"
+echo "🧪 Testing with netcat fallback..."
+# Test 3: Without nc but with netcat, port free (should exit 101)
+run_test "false" "true" "false" "Without nc but with netcat, port is free"
 cleanup_port
 
-# Test 4: Without nc but with curl, port in use (should exit 100)
-run_test "false" "true" "true" "Without netcat but with curl, port is in use"
+# Test 4: Without nc but with netcat, port in use (should exit 100)
+run_test "false" "true" "true" "Without nc but with netcat, port is in use"
 cleanup_port
 
-echo "🧪 Testing with no tools available..."
-# Test 5: Without nc and without curl (should exit 1)
-run_test "false" "false" "false" "Without netcat and without curl, should exit with code 1"
+echo "🧪 Testing with bash fallback..."
+# Test 5: Without nc and netcat, port free (should exit 101)
+run_test "false" "false" "false" "Without nc/netcat, using bash fallback, port is free"
 cleanup_port
 
-# Test 6: Without nc and without curl (should exit 1)
-run_test "false" "false" "true" "Without netcat and without curl, should exit with code 1"
+# Test 6: Without nc and netcat, port in use (should exit 100)
+run_test "false" "false" "true" "Without nc/netcat, using bash fallback, port is in use"
 cleanup_port
 
 # Cleanup


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #142

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8.0 and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
The collector connectivity check in `collector_test.sh` has issues with container name conflicts when deploying multiple slot subsets. Additionally, the port checking logic needed to be more robust across different environments where netcat might not be available.

### New expected behaviour
Port checking now uses a more reliable approach that works consistently across all environments:
- Uses `nc -z` if netcat is available
- Falls back to pure bash `/dev/tcp` check if netcat is unavailable
- Guaranteed to work on any system with bash
- Consistent behavior across all environments

### Change logs

#### Changed
- Modified port checking logic in `collector_test.sh` to use bash's built-in `/dev/tcp` capability as fallback when netcat is not available
- Updated test script `test_collector_check.sh` to properly test all port checking scenarios
- Improved error messages and handling for port checking edge cases

#### Fixed
- Fixed port checking reliability issues when netcat is not available
- Ensured consistent port checking behavior across different environments

## Deployment Instructions

* Configure `LITE_NODE_BRANCH=dockerify` in your CLI or multi setup env file and run the nodes on a system which does not have `netcat` or `nc` installed. 